### PR TITLE
Detect fader movement/touch

### DIFF
--- a/FADER_X/Fader.cpp
+++ b/FADER_X/Fader.cpp
@@ -139,7 +139,7 @@ void Fader::loop(){
 void Fader::touchLoop(){
   int pos = this->getPosition();
 
-  // constant flutter between 2 values if distance is less than 3
+  // constant flutter between 2 values if distance check is less than 3
   if(abs(globalFaderTargets[this->channel]-pos)>3 && mils-this->lastTouchEvent>globalMessageWaitMillis){
     globalFaderTargets[this->channel] = pos;
     this->lastTouchEvent = mils;
@@ -233,25 +233,25 @@ int Fader::getMode(){
   return this->mode;
 }
 void Fader::setMode(int m){
-  Serial.print("---------- mode ");
+  // Serial.print("---------- mode ");
 
-  switch(m) {
-    case FMODE_Disabled:
-      Serial.println("Disabled");
-      break;
-    case FMODE_Rest:
-      Serial.println("Rest");
-      break;
-    case FMODE_Touch:
-        Serial.println("Touch");
-      break;
-    case FMODE_Motor:
-        Serial.println("Motor");
-      break;
-    case FMODE_Pause:
-        Serial.println("Pause");
-      break;
-  }
+  // switch(m) {
+  //   case FMODE_Disabled:
+  //     Serial.println("Disabled");
+  //     break;
+  //   case FMODE_Rest:
+  //     Serial.println("Rest");
+  //     break;
+  //   case FMODE_Touch:
+  //       Serial.println("Touch");
+  //     break;
+  //   case FMODE_Motor:
+  //       Serial.println("Motor");
+  //     break;
+  //   case FMODE_Pause:
+  //       Serial.println("Pause");
+  //     break;
+  // }
   this->lastModeStart = millis();
   this->mode = m;
 }

--- a/FADER_X/Fader.cpp
+++ b/FADER_X/Fader.cpp
@@ -137,16 +137,23 @@ void Fader::loop(){
 
 
 void Fader::touchLoop(){
-  
-  if(abs(globalFaderTargets[this->channel]-this->getPosition())>1 && mils-this->lastTouchEvent>globalMessageWaitMillis){
-    globalFaderTargets[this->channel] = this->getPosition();
+  int pos = this->getPosition();
+
+  // constant flutter between 2 values if distance is less than 3
+  if(abs(globalFaderTargets[this->channel]-pos)>3 && mils-this->lastTouchEvent>globalMessageWaitMillis){
+    globalFaderTargets[this->channel] = pos;
     this->lastTouchEvent = mils;
     touchEvent(this);
   }
   
-  if(mils-this->lastTouchEvent > globalMessageWaitMillis*2 || mils-this->lastModeStart>300){ // tail debounce when after touching the fader
-    globalFaderTargets[this->channel] = this->getPosition();
-    touchEvent(this);
+  // checking against 'lastModeStart' prevents a slow (1+ second) up/down fade
+  // since it forces Rest mode after 300ms
+  // // if(mils-this->lastTouchEvent > globalMessageWaitMillis*2 || mils-this->lastModeStart>300){ // tail debounce when after touching the fader
+  // //   globalFaderTargets[this->channel] = this->getPosition();
+  if(mils-this->lastTouchEvent > 300){ 
+    // at this point, the fader hasn't moved since the last update
+    // // globalFaderTargets[this->channel] = pos;
+    // // touchEvent(this);
     setMode(FMODE_Rest);
     
   }
@@ -226,6 +233,25 @@ int Fader::getMode(){
   return this->mode;
 }
 void Fader::setMode(int m){
+  Serial.print("---------- mode ");
+
+  switch(m) {
+    case FMODE_Disabled:
+      Serial.println("Disabled");
+      break;
+    case FMODE_Rest:
+      Serial.println("Rest");
+      break;
+    case FMODE_Touch:
+        Serial.println("Touch");
+      break;
+    case FMODE_Motor:
+        Serial.println("Motor");
+      break;
+    case FMODE_Pause:
+        Serial.println("Pause");
+      break;
+  }
   this->lastModeStart = millis();
   this->mode = m;
 }


### PR DESCRIPTION
Increased the fudge factor to 'notice' a fader is moving to reduce idle flutter.
Touch to Rest Timeout now compared to last detected move.
This prevents a motor command being injected while slowly moving the fader.

This works for my FADER_4 interacting with OnPC2.
